### PR TITLE
Corrected Navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
           <div class="collapse navbar-collapse" id="navtoggle">
             <ul class="navbar-nav ms-auto">
               <li class="nav-item">
-                <a class="nav-link active" href="../index.html"> Home</a>
+                <a class="nav-link active" href="./index.html"> Home</a>
               </li>
 
               <li class="nav-item" id="lg">


### PR DESCRIPTION
### Description

The Home button in the navigation bar was supposed to link to the Home page of Pictionary. This issue was resolved.

### Checklist

- [x] I am making a proper pull request, not spam.
- [x] I've checked the issue list before deciding what to submit.
