### PR TITLE
Gallary link is not working for Quick Links #126

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
           <div class="col-sm-6 col-md-2 mb-2 mb-md-0 text-center">
             <h3>Quick Links</h3>
             <ul class="list-unstyled nav-links">
-              <li><a href="/pages/gallery/landing.html">Gallery</a></li>
+              <li><a href="./pages/gallery/landing.html">Gallery</a></li>
               <li><a href="./pages/about.html">About Us</a></li>
               <li><a href="./contributors.html">Contributors</a></li>
             </ul>


### PR DESCRIPTION
### Description

In the footer of the home page, there are Quick links for the gallery is working now

### Checklist

- [x] I am making a proper pull request, not spam.
- [x] I've checked the issue list before deciding what to submit.

### Demo Work Screenshot:

![image](https://user-images.githubusercontent.com/78480983/156734337-9b6f07f3-56be-491b-96f2-98a39a4c7d34.png)
![image](https://user-images.githubusercontent.com/78480983/156734365-1931b1d9-a8ed-4fbf-9db8-726e0b8a0057.png)
